### PR TITLE
"before all" hooks timeout for everything except badge tests

### DIFF
--- a/test/issuer.spec.js
+++ b/test/issuer.spec.js
@@ -43,12 +43,15 @@ describe('Issuer Test', function() {
         await verifyIssuerOverApi();
     });
 
+    it('should delete the issuer', async function () {
+        await deleteIssuerOverApi();
+    });
+
     afterEach(async function () {
         await screenshot(driver, this.currentTest);
     });
 
     after(async () => {
-        await deleteIssuerOverApi();
         await driver.quit();
     });
 });

--- a/test/qr.spec.js
+++ b/test/qr.spec.js
@@ -75,12 +75,15 @@ describe('QR test', function() {
         await receiveBadge(driver);
     });
 
+    it('should delete the badge', async function() {
+        await deleteBadgeOverApi();
+    });
+
     afterEach(async function () {
         await screenshot(driver, this.currentTest);
     });
 
     after(async () => {
-        await deleteBadgeOverApi();
         await driver.quit();
     });
 });

--- a/test/signup.spec.js
+++ b/test/signup.spec.js
@@ -46,12 +46,15 @@ describe('Signup Test', function() {
         await deleteUserViaUI(driver);
     });
 
+    it('should ensure user is deleted over API', async function () {
+        await deleteUserOverApi();
+    });
+
     afterEach(async function () {
         await screenshot(driver, this.currentTest);
     });
 
     after(async () => {
-        await deleteUserOverApi();  // Ensure user is deleted
         await driver.quit()
     });
 });


### PR DESCRIPTION
The problem was that the issuer creation failed, which caused the `after all` hook of the issuer to fail. Normally this would mean that the chrome application gets restarted. In selenium however, this lead to the browser becoming unresponsive, so future tests already failed at the `before all` hooks. By moving the cleanup (i.e. deletions over API) to the tests (instead of the `after all` hooks), this should solve the problem.