### PR TITLE
Feat/ob 3 test

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-export const url = "http://localhost:4200";
-export const backendUrl = "http://localhost:8000";
+export const url = "https://develop.openbadges.education";
+export const backendUrl = "https://api.develop.openbadges.education";
 export const defaultWait = 12000; // waits for a specified amount of time for a certain condition to be true.
 export const extendedWait = 25000;

--- a/test/badge.js
+++ b/test/badge.js
@@ -681,7 +681,7 @@ export async function deleteBadgesOverApi(n) {
  * @returns The content of the json file as string
  * @param {import('selenium-webdriver').ThenableWebDriver} driver
  */
-const downloadBadgeJson = async (driver, badgeName) => {
+async function downloadBadgeJson(driver, badgeName) {
   const overflowMenu = await driver.findElement(
     By.css('button:has(svg[icon="icon_more"])')
   );
@@ -712,7 +712,7 @@ const downloadBadgeJson = async (driver, badgeName) => {
  * of an awarded badge.
  * @param {import('selenium-webdriver').ThenableWebDriver} driver
  */
-export const validateBadgeVersion = async (driver) => {
+export async function validateBadgeVersion(driver) {
   const badgeStandardText = await driver.findElement(
       ExtendedBy.tagWithText("dt", "Badge-Standard")
     );
@@ -741,7 +741,7 @@ export const validateBadgeVersion = async (driver) => {
  * that will be reuploaded in a modified way.
  * @param {import('selenium-webdriver').ThenableWebDriver} driver
  */
-export const validateUploadedInvalidBadge = async (driver) => {
+export async function validateUploadedInvalidBadge(driver) {
     const file = await downloadBadgeJson(driver, testBadgeTitle);
     const badge = JSON.parse(file);
     await clearDownloadDirectory();
@@ -783,7 +783,7 @@ export const validateUploadedInvalidBadge = async (driver) => {
  * that will be reuploaded in a modified way.
  * @param {import('selenium-webdriver').ThenableWebDriver} driver
  */
-export const validateUploadedV2Badge = async (driver) => {
+export async function validateUploadedV2Badge(driver) {
     const file = await downloadBadgeJson(driver, testBadgeTitle);
     await clearDownloadDirectory();
 
@@ -850,7 +850,7 @@ export const validateUploadedV2Badge = async (driver) => {
  * that will be reuploaded in a modified way.
  * @param {import('selenium-webdriver').ThenableWebDriver} driver
  */
-export const validateUploadedV3Badge = async (driver) => {
+export async function validateUploadedV3Badge(driver) {
     const file = await downloadBadgeJson(driver, testBadgeTitle);
     await clearDownloadDirectory();
     await navigateToBackpack(driver);

--- a/test/badge.js
+++ b/test/badge.js
@@ -723,13 +723,10 @@ export async function validateBadgeVersion(driver) {
   const file = await downloadBadgeJson(driver, testBadgeTitle);
   
   const badgeAsJson = JSON.parse(file);
-  assert.equal(typeof badgeAsJson['@context'] === "string", false);
+  assert.notStrictEqual(typeof badgeAsJson['@context'], "string");
   // The existence of the /credentials/ part in the context urls are
-  // unique for v3
-  assert.equal(badgeAsJson['@context'].reduce((prev, curr) => {
-    return prev || curr.indexOf('/credentials/') >= 0
-  }, false), true);
-
+  // unique for v3. If it exists in any url, it is v3 (which it should be here)
+  assert(badgeAsJson['@context'].some(i => i.indexOf('/credentials') >= 0));
   await clearDownloadDirectory();
 };
 

--- a/test/badge.js
+++ b/test/badge.js
@@ -789,9 +789,11 @@ export async function validateUploadedV2Badge(driver) {
 
     await navigateToBackpack(driver);
 
-    const badgesBefore = Number(await (await driver.wait(until.elementLocated(
+    const badgeCountElement = await driver.wait(until.elementLocated(
         By.css('div:has(div > ng-icon[name="lucideHexagon"]) > p')
-    ), defaultWait)).getAttribute('ng-reflect-end-val'));
+    ), defaultWait);
+    const badgeCountAttribute = await badgeCountElement.getAttribute('ng-reflect-end-val');
+    const badgesBefore = Number(badgeCountAttribute);
 
     const uploadButton = await driver.wait(until.elementLocated(
       ExtendedBy.submitButtonWithText('Badge hochladen')

--- a/test/badge.js
+++ b/test/badge.js
@@ -789,11 +789,14 @@ async function uploadBadgeJson(driver, badgeJson) {
  * @param {import('selenium-webdriver').ThenableWebDriver} driver 
  */
 async function dismissNotificationToast(driver) {
-    const notificationDismissButton = await driver.findElement(
+    const notificationDismissButton = await driver.findElements(
         By.css('button.notification-x-close')
-    ).then(undefined, _ => null);
-    if(notificationDismissButton !== null)
-        await notificationDismissButton.click();
+    );
+    if(notificationDismissButton.length > 0) {
+        // There can only ever be one toast at a time
+        assert(notificationDismissButton.length === 1);
+        await notificationDismissButton[0].click();
+    }
 }
 
 /**

--- a/test/badge.js
+++ b/test/badge.js
@@ -788,9 +788,12 @@ export const validateUploadedV2Badge = async (driver) => {
     const v2Url = badge['id'].replace('3_0', '2_0');
     const badgeV2Response = await fetch(v2Url);
     const badgeV2JsonString = await badgeV2Response.text();
-    console.log(badgeV2JsonString);
 
     await navigateToBackpack(driver);
+
+    const badgesBefore = Number(await (await driver.findElement(
+        By.css('div:has(div > ng-icon[name="lucideHexagon"]) > p')
+    )).getAttribute('ng-reflect-end-val'));
 
     const uploadButton = await driver.wait(until.elementLocated(
       ExtendedBy.submitButtonWithText('Badge hochladen')
@@ -812,7 +815,10 @@ export const validateUploadedV2Badge = async (driver) => {
     );
     await sendBadgeForUploadButton.click();
 
-    await navigateToBackpack(driver);
+    // Wait until dialog disappears and the backpack updated itself
+    await driver.wait(until.elementLocated(
+        By.css(`div:has(div > ng-icon[name="lucideHexagon"]) > p[ng-reflect-end-val='${badgesBefore + 1}']`)
+    ));
 
     const importedBadge = await driver.wait(until.elementLocated(
       By.css(`bg-badgecard:has(div.tw-absolute.tw-top-0) a[title='${testBadgeTitle}']`)
@@ -830,7 +836,7 @@ export const validateUploadedV2Badge = async (driver) => {
     await deleteFromBackpackButton.click();
 
     const confirmDeleteButton = await driver.findElement(
-      ExtendedBy.tagWithText('button', 'OK')
+      ExtendedBy.tagWithText('button', 'Badge entfernen')
     );
     await confirmDeleteButton.click();
 };
@@ -884,7 +890,7 @@ export const validateUploadedV3Badge = async (driver) => {
     await deleteFromBackpackButton.click();
 
     const confirmDeleteButton = await driver.findElement(
-      ExtendedBy.tagWithText('button', 'OK')
+      ExtendedBy.tagWithText('button', 'Badge entfernen')
     );
     await confirmDeleteButton.click();
 };

--- a/test/badge.js
+++ b/test/badge.js
@@ -749,12 +749,12 @@ export async function validateUploadedInvalidBadge(driver) {
 
     const uploadButton = await driver.wait(until.elementLocated(
       By.css('oeb-button[icon="lucideUpload"]')
-    ));
+    ), defaultWait);
     await uploadButton.click();
 
     const jsonButton = await driver.wait(until.elementLocated(
-      By.css('form hlm-tabs-list button:nth-child(3)'))
-    );
+      By.css('form hlm-tabs-list button:nth-child(3)')
+    ), defaultWait);
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
@@ -791,16 +791,16 @@ export async function validateUploadedV2Badge(driver) {
 
     const badgesBefore = Number(await (await driver.wait(until.elementLocated(
         By.css('div:has(div > ng-icon[name="lucideHexagon"]) > p')
-    ))).getAttribute('ng-reflect-end-val'));
+    ), defaultWait)).getAttribute('ng-reflect-end-val'));
 
     const uploadButton = await driver.wait(until.elementLocated(
       ExtendedBy.submitButtonWithText('Badge hochladen')
-    ));
+    ), defaultWait);
     await uploadButton.click();
 
     const jsonButton = await driver.wait(until.elementLocated(
-      By.css('form hlm-tabs-list button:nth-child(3)'))
-    );
+      By.css('form hlm-tabs-list button:nth-child(3)')
+    ), defaultWait);
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
@@ -816,16 +816,16 @@ export async function validateUploadedV2Badge(driver) {
     // Wait until dialog disappears and the backpack updated itself
     await driver.wait(until.elementLocated(
         By.css(`div:has(div > ng-icon[name="lucideHexagon"]) > p[ng-reflect-end-val='${badgesBefore + 1}']`)
-    ));
+    ), defaultWait);
 
     const importedBadge = await driver.wait(until.elementLocated(
       By.css(`bg-badgecard:has(div.tw-absolute.tw-top-0) a[title='${testBadgeTitle}']`)
-    ));
+    ), defaultWait);
     await importedBadge.click();
 
     const overflowMenu = await driver.wait(until.elementLocated(
       By.css('button:has(svg[icon="icon_more"])')
-    ));
+    ), defaultWait);
     await overflowMenu.click();
 
     const deleteFromBackpackButton = await driver.findElement(
@@ -852,12 +852,12 @@ export async function validateUploadedV3Badge(driver) {
 
     const uploadButton = await driver.wait(until.elementLocated(
       ExtendedBy.submitButtonWithText('Badge hochladen')
-    ));
+    ), defaultWait);
     await uploadButton.click();
 
     const jsonButton = await driver.wait(until.elementLocated(
-      By.css('form hlm-tabs-list button:nth-child(3)'))
-    );
+      By.css('form hlm-tabs-list button:nth-child(3)')
+    ), defaultWait);
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
@@ -874,12 +874,12 @@ export async function validateUploadedV3Badge(driver) {
 
     const importedBadge = await driver.wait(until.elementLocated(
       By.css(`bg-badgecard:has(div.tw-absolute.tw-top-0) a[title='${testBadgeTitle}']`)
-    ));
+    ), defaultWait);
     await importedBadge.click();
 
     const overflowMenu = await driver.wait(until.elementLocated(
       By.css('button:has(svg[icon="icon_more"])')
-    ));
+    ), defaultWait);
     await overflowMenu.click();
 
     const deleteFromBackpackButton = await driver.findElement(

--- a/test/badge.js
+++ b/test/badge.js
@@ -38,6 +38,7 @@ const aiCompetenciesDescriptionText = 'With solid computer skills, you can autom
 const tagName = 'automated test tag';
 const microDegreeTitle = 'automated micro degree';
 const microDegreeDescription = 'automated micro degree description';
+const currentBadgeStandardVersion = '3.0'
 
 
 /**
@@ -520,6 +521,15 @@ export async function validateBadge(driver, badgeType = 'Teilnahme') {
 
     const divElements = await driver.findElements(By.css('div.tag'));
     assert.equal(divElements.length, 1);
+
+    const badgeStandardText = await driver.findElement(
+      ExtendedBy.tagWithText("dt", "Badge-Standard")
+    );
+    const badgeStandardVersion = await driver.findElement(
+      ExtendedBy.sibling(badgeStandardText, By.css("dd"))
+    );
+    const badgeStandardVersionText = await badgeStandardVersion.getText();
+    assert.equal(badgeStandardVersionText, currentBadgeStandardVersion);
 
     const categoryHeading = await driver.findElement(
         ExtendedBy.tagWithText('dt', 'Kategorie'));

--- a/test/badge.js
+++ b/test/badge.js
@@ -692,16 +692,14 @@ async function downloadBadgeJson(driver, badgeName) {
   );
   await downloadButton.click();
 
-  await waitForDownload(driver, new RegExp(/^\d{4}-\d{2}-\d{2}-[a-zA-Z0-9_ ]+\.json$/));
-
-  const now = new Date();
-  const badgeJsonName =
-    `${now.getFullYear()}-` +
-    `${('0' + (now.getMonth()+1)).slice(-2)}-` +
-    `${('0' + (now.getDate())).slice(-2)}-` +
-    `${badgeName.replace(' ', '_')}.json`;
-  const file = fs.readFileSync(`${downloadDirectory}/${badgeJsonName}`, { encoding: 'utf-8' });
-  return file;
+  // RegExp for a file like 2025-06-16-some_text.json
+  const badgeJsonRegex = new RegExp(/^\d{4}-\d{2}-\d{2}-[a-zA-Z0-9_]+\.json$/);
+  await waitForDownload(driver, badgeJsonRegex);
+  
+  const files = fs.readFileSync(downloadDirectory);
+  const file = files.filter(f => badgeJsonRegex.test(f))
+  const fileContent = Buffer.from(file).toString('utf-8');
+  return fileContent;
 };
 
 /**

--- a/test/badge.js
+++ b/test/badge.js
@@ -752,9 +752,9 @@ export const validateUploadedInvalidBadge = async (driver) => {
 
     await navigateToBackpack(driver);
 
-    const uploadButton = await driver.findElement(
-      ExtendedBy.submitButtonWithText('Badge hochladen')
-    );
+    const uploadButton = await driver.wait(until.elementLocated(
+      By.css('oeb-button[icon="lucideUpload"]')
+    ));
     await uploadButton.click();
 
     const jsonButton = await driver.wait(until.elementLocated(
@@ -763,7 +763,7 @@ export const validateUploadedInvalidBadge = async (driver) => {
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
-      By.css('textarea#json_eingeben')
+      By.css('textarea[name="json_eingeben"]')
     );
     await jsonTextarea.sendKeys(badgeStringToUpload);
 
@@ -794,9 +794,9 @@ export const validateUploadedV2Badge = async (driver) => {
 
     await navigateToBackpack(driver);
 
-    const badgesBefore = Number(await (await driver.findElement(
+    const badgesBefore = Number(await (await driver.wait(until.elementLocated(
         By.css('div:has(div > ng-icon[name="lucideHexagon"]) > p')
-    )).getAttribute('ng-reflect-end-val'));
+    ))).getAttribute('ng-reflect-end-val'));
 
     const uploadButton = await driver.wait(until.elementLocated(
       ExtendedBy.submitButtonWithText('Badge hochladen')
@@ -809,7 +809,7 @@ export const validateUploadedV2Badge = async (driver) => {
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
-      By.css('textarea#json_eingeben')
+      By.css('textarea[name="json_eingeben"]')
     );
     await jsonTextarea.sendKeys(badgeV2JsonString);
 
@@ -866,7 +866,7 @@ export const validateUploadedV3Badge = async (driver) => {
     await jsonButton.click();
 
     const jsonTextarea = await driver.findElement(
-      By.css('textarea#json_eingeben')
+      By.css('textarea[name="json_eingeben"]')
     );
     await jsonTextarea.sendKeys(file);
 

--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -46,10 +46,9 @@ const BADGES_FOR_MICRO_DEGREE = 3;
 /** Extra timeout granted per badge for micro degree tests */
 const EXTRA_TIMEOUT_PER_BADGE_MS = 10_000;
 
-
+let driver;
 describe('Badge Test', function() {
-    this.timeout(GLOBAL_TIMEOUT_MS);
-    let driver;
+    this.timeout(GLOBAL_TIMEOUT_MS);    
 
     before(async () => {
         // Delete all PDFs from tmp directory
@@ -93,10 +92,6 @@ describe('Badge Test', function() {
 
         it('delete the participation badge', async function() {
             await deleteBadgeOverApi();
-        });
-
-        afterEach(async function () {
-            await screenshot(driver, this.currentTest);
         });
     });
 
@@ -146,10 +141,6 @@ describe('Badge Test', function() {
 
         it('delete the competency badge', async function() {
             await deleteBadgeOverApi();
-        });
-
-        afterEach(async function () {
-            await screenshot(driver, this.currentTest);
         });
     });
 
@@ -213,39 +204,33 @@ describe('Badge Test', function() {
         it('should delete the badges for the micro degree', async function () {
             await deleteBadgesOverApi(BADGES_FOR_MICRO_DEGREE);
         });
-
-        afterEach(async function () {
-            await screenshot(driver, this.currentTest);
-        });
     });
 
     describe('badge upload', () => {
-        // it('should create a badge to test with', async function() {
-        //     await navigateToBadgeCreation(driver);
-        //     await createBadge(driver);
-        // });
+        it('should create a badge to test with', async function() {
+            await navigateToBadgeCreation(driver);
+            await createBadge(driver);
+            await navigateToBadgeAwarding(driver);
+            await awardBadge(driver);
+        });
 
-        // it('should show message when uploaded badge is invalid', async () => {
-        //     await navigateToReceivedBadge(driver);
-        //     await validateUploadedInvalidBadge(driver);
-        // });
+        it('should show message when uploaded badge is invalid', async () => {
+            await navigateToReceivedBadge(driver);
+            await validateUploadedInvalidBadge(driver);
+        });
 
         it('should validate a v2 badge as such on upload', async () => {
             await navigateToReceivedBadge(driver);
             await validateUploadedV2Badge(driver);
         });
 
-        // it('should validate a v3 badge as such on upload', async () => {
-            // await navigateToReceivedBadge(driver);
-            // await validateUploadedV3Badge(driver);
-        // });        
+        it('should validate a v3 badge as such on upload', async () => {
+            await navigateToReceivedBadge(driver);
+            await validateUploadedV3Badge(driver);
+        });
 
-        // it('delete the badge to test with', async function() {
-        //     await deleteBadgeOverApi();
-        // });
-
-        afterEach(async function () {
-            await screenshot(driver, this.currentTest);
+        it('delete the badge to test with', async function() {
+            await deleteBadgeOverApi();
         });
     });
 
@@ -253,3 +238,7 @@ describe('Badge Test', function() {
         await driver.quit();
     });
 });
+
+afterEach(async function () {
+    await screenshot(driver, this.currentTest);
+});   

--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -76,132 +76,142 @@ describe('Badge Test', function() {
     });
 
     // Participation badge
-    it('should create a participation badge', async function() {
-        await navigateToBadgeCreation(driver);
-        await createBadge(driver);
+    describe('Participation badge', () => {
+        it('should create a participation badge', async function() {
+            await navigateToBadgeCreation(driver);
+            await createBadge(driver);
+        });
+
+        it('should validate the participation badge', async function() {
+            await navigateToBadgeDetails(driver);
+            await validateBadge(driver);
+            await verifyBadgeOverApi(driver);
+        });
+
+        it('delete the participation badge', async function() {
+            await deleteBadgeOverApi();
+        });
+
+        afterEach(screenshot(driver, this.currentTest));
     });
 
-    it('should validate the participation badge', async function() {
-        await navigateToBadgeDetails(driver);
-        await validateBadge(driver);
-        await verifyBadgeOverApi(driver);
-    });
+    describe('Competency badge', () => {
+        it('should create a competency badge', async function() {
+            await navigateToBadgeCreation(driver);
+            await createBadge(driver, 'competency');
+        });
 
-    it('delete the participation badge', async function() {
-        await deleteBadgeOverApi();
-    });
+        it('should validate the competency badge', async function() {
+            await navigateToBadgeDetails(driver);
+            await validateBadge(driver, 'Kompetenz');
+            await verifyBadgeOverApi(driver);
+        });
 
-    // Competency badge
-    it('should create a competency badge', async function() {
-        await navigateToBadgeCreation(driver);
-        await createBadge(driver, 'competency');
-    });
-
-    it('should validate the competency badge', async function() {
-        await navigateToBadgeDetails(driver);
-        await validateBadge(driver, 'Kompetenz');
-        await verifyBadgeOverApi(driver);
-    });
-
-    it('should award the competency badge', async function() {
-        await navigateToBadgeAwarding(driver);
-        await awardBadge(driver);
-    });
-
-    it('should receive the competency badge', async function() {
-        await navigateToBackpack(driver);
-        await receiveBadge(driver);
-    });
-
-    it('should ensure the received badge is of the latest open badges standard', async () => {
-        await navigateToReceivedBadge(driver);
-        await validateBadgeVersion(driver);
-    });
-
-    it('should download the pdf from the backpack', async function() {
-        await navigateToReceivedBadge(driver);
-        await downloadPdfFromBackpack(driver);
-    });
-
-    it('should download the pdf from the internal issuer page', async function() {
-        await navigateToBadgeDetails(driver);
-        await downloadPdfFromIssuer(driver);
-    });
-
-    it('should revoke the competency badge', async function() {
-        await navigateToBadgeDetails(driver);
-        await revokeBadge(driver);
-        await navigateToBackpack(driver);
-        await confirmRevokedBadge(driver);
-    });
-
-    it('delete the competency badge', async function() {
-        await deleteBadgeOverApi();
-    });
-
-    // micro degree
-    it('should create a micro degree', async () => {
-        // We need at least three badges to put as part of the degree
-        await createBadges(driver, BADGES_FOR_MICRO_DEGREE);
-        await navigateToBadgeCreation(driver);
-        await createMicroDegree(driver, BADGES_FOR_MICRO_DEGREE);
-    })
-    .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since a number of badges have to be created
-
-    it('should award the micro degree', async function() {
-        // users get micro degrees automatically by receiving all badges
-        // contained in the degree itself
-        for(let i = 0; i < BADGES_FOR_MICRO_DEGREE; i++) {
-            await navigateToBadgeAwarding(driver, i);
+        it('should award the competency badge', async function() {
+            await navigateToBadgeAwarding(driver);
             await awardBadge(driver);
-        }
-    })
-    .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since awarding badges takes a while
+        });
 
-    it('should receive the micro degree', async function() {
-        await navigateToBackpack(driver);
-        await receiveMicroDegreeBadge(driver);
-    });
+        it('should receive the competency badge', async function() {
+            await navigateToBackpack(driver);
+            await receiveBadge(driver);
+        });
 
-    it('should download the micro degree pdf from the backpack', async function() {
-        await navigateToBackpack(driver);
-        await navigateToReceivedMicroDegree(driver);
-        // https://github.com/mint-o-badges/badgr-ui/issues/1231
-        // A delay is required here due to a race condition in the application.
-        // If removed, the download button will be clicked but won't trigger a download.
-        await new Promise(resolve => setTimeout(resolve, 1_000));
-        await downloadMicroDegree(driver);
-    });
+        it('should ensure the received badge is of the latest open badges standard', async () => {
+            await navigateToReceivedBadge(driver);
+            await validateBadgeVersion(driver);
+        });
 
-    it('should download the micro degree pdf from the internal issuer page', async function() {
-        await navigateToMicroDegreeDetails(driver);
-        await downloadPdfFromIssuer(driver);
-    });
+        it('should download the pdf from the backpack', async function() {
+            await navigateToReceivedBadge(driver);
+            await downloadPdfFromBackpack(driver);
+        });
 
-    it('should revoke the micro degree', async function() {
-        for(let i = 0; i < BADGES_FOR_MICRO_DEGREE; i++)
-        {
-            await navigateToBadgeDetails(driver, i);
+        it('should download the pdf from the internal issuer page', async function() {
+            await navigateToBadgeDetails(driver);
+            await downloadPdfFromIssuer(driver);
+        });
+
+        it('should revoke the competency badge', async function() {
+            await navigateToBadgeDetails(driver);
             await revokeBadge(driver);
-        }
-        await navigateToMicroDegreeDetails(driver);
-        await revokeMicroDegree(driver);
+            await navigateToBackpack(driver);
+            await confirmRevokedBadge(driver);
+        });
 
-        await navigateToBackpack(driver);
-        await confirmRevokedMicroDegree(driver);
-    })
-    .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since there is a number of badges to revoke
+        it('delete the competency badge', async function() {
+            await deleteBadgeOverApi();
+        });
 
-    it('should delete the micro degree', async function() {
-        await deleteMicroDegreeOverApi();
+        afterEach(screenshot(driver, this.currentTest));
     });
 
-    it('should delete the badges for the micro degree', async function () {
-        await deleteBadgesOverApi(BADGES_FOR_MICRO_DEGREE);
+    describe('micro degree', () => {
+        it('should create a micro degree', async () => {
+            // We need at least three badges to put as part of the degree
+            await createBadges(driver, BADGES_FOR_MICRO_DEGREE);
+            await navigateToBadgeCreation(driver);
+            await createMicroDegree(driver, BADGES_FOR_MICRO_DEGREE);
+        })
+        .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since a number of badges have to be created
+
+        it('should award the micro degree', async function() {
+            // users get micro degrees automatically by receiving all badges
+            // contained in the degree itself
+            for(let i = 0; i < BADGES_FOR_MICRO_DEGREE; i++) {
+                await navigateToBadgeAwarding(driver, i);
+                await awardBadge(driver);
+            }
+        })
+        .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since awarding badges takes a while
+
+        it('should receive the micro degree', async function() {
+            await navigateToBackpack(driver);
+            await receiveMicroDegreeBadge(driver);
+        });
+
+        it('should download the micro degree pdf from the backpack', async function() {
+            await navigateToBackpack(driver);
+            await navigateToReceivedMicroDegree(driver);
+            // https://github.com/mint-o-badges/badgr-ui/issues/1231
+            // A delay is required here due to a race condition in the application.
+            // If removed, the download button will be clicked but won't trigger a download.
+            await new Promise(resolve => setTimeout(resolve, 1_000));
+            await downloadMicroDegree(driver);
+        });
+
+        it('should download the micro degree pdf from the internal issuer page', async function() {
+            await navigateToMicroDegreeDetails(driver);
+            await downloadPdfFromIssuer(driver);
+        });
+
+        it('should revoke the micro degree', async function() {
+            for(let i = 0; i < BADGES_FOR_MICRO_DEGREE; i++)
+            {
+                await navigateToBadgeDetails(driver, i);
+                await revokeBadge(driver);
+            }
+            await navigateToMicroDegreeDetails(driver);
+            await revokeMicroDegree(driver);
+
+            await navigateToBackpack(driver);
+            await confirmRevokedMicroDegree(driver);
+        })
+        .timeout(this.timeout() + BADGES_FOR_MICRO_DEGREE * EXTRA_TIMEOUT_PER_BADGE_MS); // Allow larger timeout since there is a number of badges to revoke
+
+        it('should delete the micro degree', async function() {
+            await deleteMicroDegreeOverApi();
+        });
+
+        it('should delete the badges for the micro degree', async function () {
+            await deleteBadgesOverApi(BADGES_FOR_MICRO_DEGREE);
+        });
+
+        afterEach(screenshot(driver, this.currentTest));
     });
 
-    afterEach(async function () {
-        await screenshot(driver, this.currentTest);
+    describe('badge upload', () => {
+        afterEach(screenshot(driver, this.currentTest));
     });
 
     after(async () => {

--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -31,7 +31,10 @@ import {
     navigateToReceivedMicroDegree,
     navigateToMicroDegreeDetails,
     revokeMicroDegree,
-    validateBadgeVersion
+    validateBadgeVersion,
+    validateUploadedV2Badge,
+    validateUploadedV3Badge,
+    validateUploadedInvalidBadge
 } from './badge.js';
 
 /** Global timeout for all tests if not specified otherwise */
@@ -76,7 +79,7 @@ describe('Badge Test', function() {
     });
 
     // Participation badge
-    describe('Participation badge', () => {
+    describe.skip('Participation badge', () => {
         it('should create a participation badge', async function() {
             await navigateToBadgeCreation(driver);
             await createBadge(driver);
@@ -92,10 +95,12 @@ describe('Badge Test', function() {
             await deleteBadgeOverApi();
         });
 
-        afterEach(screenshot(driver, this.currentTest));
+        afterEach(async function () {
+            await screenshot(driver, this.currentTest);
+        });
     });
 
-    describe('Competency badge', () => {
+    describe.skip('Competency badge', () => {
         it('should create a competency badge', async function() {
             await navigateToBadgeCreation(driver);
             await createBadge(driver, 'competency');
@@ -143,10 +148,12 @@ describe('Badge Test', function() {
             await deleteBadgeOverApi();
         });
 
-        afterEach(screenshot(driver, this.currentTest));
+        afterEach(async function () {
+            await screenshot(driver, this.currentTest);
+        });
     });
 
-    describe('micro degree', () => {
+    describe.skip('micro degree', () => {
         it('should create a micro degree', async () => {
             // We need at least three badges to put as part of the degree
             await createBadges(driver, BADGES_FOR_MICRO_DEGREE);
@@ -207,11 +214,39 @@ describe('Badge Test', function() {
             await deleteBadgesOverApi(BADGES_FOR_MICRO_DEGREE);
         });
 
-        afterEach(screenshot(driver, this.currentTest));
+        afterEach(async function () {
+            await screenshot(driver, this.currentTest);
+        });
     });
 
     describe('badge upload', () => {
-        afterEach(screenshot(driver, this.currentTest));
+        // it('should create a badge to test with', async function() {
+        //     await navigateToBadgeCreation(driver);
+        //     await createBadge(driver);
+        // });
+
+        // it('should show message when uploaded badge is invalid', async () => {
+        //     await navigateToReceivedBadge(driver);
+        //     await validateUploadedInvalidBadge(driver);
+        // });
+
+        it('should validate a v2 badge as such on upload', async () => {
+            await navigateToReceivedBadge(driver);
+            await validateUploadedV2Badge(driver);
+        });
+
+        // it('should validate a v3 badge as such on upload', async () => {
+            // await navigateToReceivedBadge(driver);
+            // await validateUploadedV3Badge(driver);
+        // });        
+
+        // it('delete the badge to test with', async function() {
+        //     await deleteBadgeOverApi();
+        // });
+
+        afterEach(async function () {
+            await screenshot(driver, this.currentTest);
+        });
     });
 
     after(async () => {

--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -30,7 +30,8 @@ import {
     downloadMicroDegree,
     navigateToReceivedMicroDegree,
     navigateToMicroDegreeDetails,
-    revokeMicroDegree
+    revokeMicroDegree,
+    validateBadgeVersion
 } from './badge.js';
 
 /** Global timeout for all tests if not specified otherwise */
@@ -110,6 +111,11 @@ describe('Badge Test', function() {
     it('should receive the competency badge', async function() {
         await navigateToBackpack(driver);
         await receiveBadge(driver);
+    });
+
+    it('should ensure the received badge is of the latest open badges standard', async () => {
+        await navigateToReceivedBadge(driver);
+        await validateBadgeVersion(driver);
     });
 
     it('should download the pdf from the backpack', async function() {

--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -78,7 +78,7 @@ describe('Badge Test', function() {
     });
 
     // Participation badge
-    describe.skip('Participation badge', () => {
+    describe('Participation badge', () => {
         it('should create a participation badge', async function() {
             await navigateToBadgeCreation(driver);
             await createBadge(driver);
@@ -95,7 +95,7 @@ describe('Badge Test', function() {
         });
     });
 
-    describe.skip('Competency badge', () => {
+    describe('Competency badge', () => {
         it('should create a competency badge', async function() {
             await navigateToBadgeCreation(driver);
             await createBadge(driver, 'competency');
@@ -144,7 +144,7 @@ describe('Badge Test', function() {
         });
     });
 
-    describe.skip('micro degree', () => {
+    describe('micro degree', () => {
         it('should create a micro degree', async () => {
             // We need at least three badges to put as part of the degree
             await createBadges(driver, BADGES_FOR_MICRO_DEGREE);


### PR DESCRIPTION
Issue: mint-o-badges/badgr-ui#1303
This PR adds tests for checking if new badges are v3 for changes made in mint-o-badges/badgr-ui#1156

**DO NOT MERGE UNTIL PARENT ISSUE IS MERGED** 

Details:
- Check if newly awarded badges are indeed v3
- Upload an invalid badge as json to the backpack and check if error is shown
- Upload a valid v2 badge as json to the backpack
- Upload a valid v3 badge as json to the backpack
- Organize tests for individual badge types into multiple nested `describes` for easier skipping during development and better log output

<details>
<summar>Draft PR text w/ thoughts about moving to multiple test groups</summar>
@timber-they This is still a draft, because I noticed some issues with the implementation on the branch I am throwing these against. These have to be addressed before a final review.
However I would like your early opinion on the last point of the above details ("Organize tests...").
Do you think we should do that for other test suites as well?
I realized its quite nice to add `skip` to the describes you are not interested in, to speed up executing the tests during development. Only drawback is that we have to repeat the `afterEach` hook.
Depending on your feedback, should I apply this with this PR to the other .spec.ts files as well (as necessary)?
</details>