### PR TITLE
add cleanup of badges as teardown structure

### DIFF
--- a/fixtures.mjs
+++ b/fixtures.mjs
@@ -1,0 +1,32 @@
+import {
+    findBadges,
+    requestToken,
+    findAssertions,
+    revokeAssertions,
+    deleteBadge
+} from './util/api.js';
+import {username, password} from './secret.js';
+
+// Cleans up possible residues of the test execution
+export async function mochaGlobalTeardown() {
+    console.log("Tearing down...");
+
+    await cleanupBadges();
+
+    console.log("Teardown completed.");
+};
+
+async function cleanupBadges() {
+    const token = await requestToken(username, password);
+    const badges = await findBadges(token, 'automated', true);
+    for (let badge of badges) {
+        const assertions = await findAssertions(token, badge.entityId);
+        await revokeAssertions(token, assertions);
+        await deleteBadge(token, badge.entityId);
+    }
+
+    const residue = await findBadges(token, 'automated', true);
+    if (residue.length != 0)
+        console.error("Didn't succeed in deleting residue badges");
+}
+

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
         "pdf2pic": "^3.1.3",
         "selenium-webdriver": "^4.24.0",
         "sharp": "^0.33.5"
+    },
+    "mocha": {
+        "require": "fixtures.mjs"
     }
 }

--- a/util/api.js
+++ b/util/api.js
@@ -133,7 +133,19 @@ export async function findBadge(token, name) {
     const result = json.result;
     if (!Array.isArray(result))
         return null;
-    return result.find(obj => obj.name == name)
+    return result.find(obj => obj.name === name);
+}
+
+export async function findBadges(token, name, startsWith=false) {
+    const path = `${backendUrl}/v2/badgeclasses`;
+    const response = await request(path, 'GET', '', token);
+
+    const json = await response.json();
+    const result = json.result;
+    if (!Array.isArray(result))
+        return [];
+    return result.filter(obj => obj.name === name ||
+        (startsWith && obj.name && obj.name.startsWith(name)));
 }
 
 export async function findAssertions(token, badgeId) {


### PR DESCRIPTION
Residue badges were so far the main error caused by residues from previous runs I identified. I think we can add further teardown cleanups if necessary later.