### PR TITLE
fix: always use word 'should' to enable filtering for it

### DIFF
--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -90,7 +90,7 @@ describe('Badge Test', function() {
             await verifyBadgeOverApi(driver);
         });
 
-        it('delete the participation badge', async function() {
+        it('should delete the participation badge', async function() {
             await deleteBadgeOverApi();
         });
     });
@@ -140,7 +140,7 @@ describe('Badge Test', function() {
             await confirmRevokedBadge(driver);
         });
 
-        it('delete the competency badge', async function() {
+        it('should delete the competency badge', async function() {
             await deleteBadgeOverApi();
         });
     });
@@ -230,7 +230,7 @@ describe('Badge Test', function() {
             await validateUploadedV3Badge(driver);
         });
 
-        it('delete the badge to test with', async function() {
+        it('should delete the badge to test with', async function() {
             await deleteBadgeOverApi();
         });
     });


### PR DESCRIPTION
This is required for changes to the testrunner to work, since it filters for the keyword `should` at the beginning of a test to figure out what is the batch / super category and what is the single test. Belongs to https://github.com/orgs/mint-o-badges/projects/2/views/1?pane=issue&itemId=119328886&issue=mint-o-badges%7Ctestrunner%7C4.