### PR TITLE
oeb-test: Screenshots fail due to `NoSuchSessionError`

### DIFF
--- a/test/badge.spec.js
+++ b/test/badge.spec.js
@@ -235,15 +235,16 @@ describe('Badge Test', function() {
         });
     });
 
+    afterEach(async function () {
+        try {
+            await screenshot(driver, this.currentTest);
+        } catch(e) {
+            console.error(`Screenshotting failed: ${e}`);
+        }
+    });   
+
     after(async () => {
         await driver.quit();
     });
 });
 
-afterEach(async function () {
-    try {
-        await screenshot(driver, this.currentTest);
-    } catch(e) {
-        console.error(`Screenshotting failed: ${e}`);
-    }
-});   

--- a/util/screenshot.js
+++ b/util/screenshot.js
@@ -8,10 +8,9 @@ export async function screenshot(driver, currentTest) {
     // Take a screenshot of the result page
     const filename = currentTest.fullTitle()
         .replace(/['"]+/g, '')
-            .replace(/[^a-z0-9]/gi, '_')
-            .toLowerCase();;
-            const encodedString = await driver.takeScreenshot();
-            await fs.writeFileSync(`./screenshots/${filename}.png`,
-                encodedString, 'base64');
-
+        .replace(/[^a-z0-9]/gi, '_')
+        .toLowerCase();
+    const encodedString = await driver.takeScreenshot();
+    await fs.writeFileSync(`./screenshots/${filename}.png`,
+        encodedString, 'base64');
 }


### PR DESCRIPTION
Keep badge screenshotting to badge tests: Because the `afterEach` hook in `badge.spec.js` was outside of the outmost `describe` block, it ran after each test of *all* batches; so also of e.g. the issuer tests. I *assume* that this caused the error message to get logged. This also means that the screenshotting actually wasn't unsuccessful, because the "normal" screenshot *probably* worked.

I wasn't able to replicate the error locally though, so we'll have to see if this actually fixes the problem.