### PR TITLE
fix: use the only submit button on the page

### DIFF
--- a/test/issuer.js
+++ b/test/issuer.js
@@ -81,8 +81,8 @@ export async function createIssuer(driver) {
         ('hlm-checkbox-checkicon'));
     await confirmCheckbox.click();
 
-    const submitButton = (await driver.findElements(By.css(
-        'button[type="submit"]')))[1];
+    const submitButton = (await driver.findElement(By.css(
+        'button[type="submit"]')));
     await submitButton.click();
 
     await driver.wait(until.titleIs(`Issuer - ${testIssuerName} - Open Educational Badges`), defaultWait);


### PR DESCRIPTION
In a recent change (mint-o-badges/badgr-ui#1397) we removed multiple submit buttons on several pages in badgr-ui.
Forms should only ever have one, so this was semantically questionable. 

As a consequence this test broke and this PR now reverts to the only submit button still left.
I reviewed all tests for `submit` occurences and thankfully only found this one.